### PR TITLE
Add rspec expectations and some tweaking

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,6 @@
 require 'bundler/gem_tasks'
-require 'rake/testtask'
+require 'rspec/core/rake_task'
 
-Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
-  test.test_files = FileList['test/**/*.rb']
-  test.verbose = true
-end
+RSpec::Core::RakeTask.new(:spec)
 
-task :default => :test
+task :default => :spec

--- a/lib/fluent/plugin/parser_monolog.rb
+++ b/lib/fluent/plugin/parser_monolog.rb
@@ -3,50 +3,49 @@ require 'json'
 
 module Fluent
   module Plugin
-    class TextParser
-      class MonologParser < Parser
-        Fluent::Plugin.register_parser('monolog', self)
+    class MonologParser < Parser
+      Fluent::Plugin.register_parser('monolog', self)
 
-        REGEXP = /^\[(?<time>[\d\-]+ [\d\:]+)\] (?<channel>.+)\.(?<level>(DEBUG|INFO|NOTICE|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY))\: (?<message>[^\{\}]*) (?<context>(\{.+\})|(\[.*\])) (?<extra>(\{.+\})|(\[.*\]))\s*$/
-        TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+      REGEXP = /^\[(?<time>[\d\-]+ [\d\:]+)\] (?<channel>.+)\.(?<level>(DEBUG|INFO|NOTICE|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY))\: (?<message>[^\{\}]*) (?<context>(\{.+\})|(\[.*\])) (?<extra>(\{.+\})|(\[.*\]))\s*$/
+      TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
-        def initialize
-          super
-          @time_parser = TimeParser.new(TIME_FORMAT)
-          @mutex = Mutex.new
+      def initialize
+        super
+        @time_parser = TimeParser.new(TIME_FORMAT)
+        @mutex = Mutex.new
+      end
+
+      def patterns
+        {'format' => REGEXP, 'time_format' => TIME_FORMAT}
+      end
+
+      def parse(text)
+        m = REGEXP.match(text)
+        unless m
+          yield nil, nil
+          return
         end
 
-        def patterns
-          {'format' => REGEXP, 'time_format' => TIME_FORMAT}
-        end
+        time = m['time']
+        time = @mutex.synchronize { @time_parser.parse(time) }
 
-        def parse(text)
-          m = REGEXP.match(text)
-          unless m
-            yield nil, nil
-            return
-          end
+        channel = m['channel']
+        level = m['level']
+        message = m['message']
+        context = JSON.parse(m['context'])
 
-          time = m['time']
-          time = @mutex.synchronize { @time_parser.parse(time) }
+        extra = JSON.parse(m['extra'])
 
-          channel = m['channel']
-          level = m['level']
-          message = m['message']
-          context = JSON.parse(m['context'])
-          extra = JSON.parse(m['extra'])
+        record = {
+          "channel" => channel,
+          "level" => level,
+          "message" => message,
+          "context" => context,
+          "extra" => extra
+        }
+        record["time"] = m['time'] if @keep_time_key
 
-          record = {
-              "channel" => channel,
-              "level" => level,
-              "message" => message,
-              "context" => context,
-              "extra" => extra
-          }
-          record["time"] = m['time'] if @keep_time_key
-
-          yield time, record
-        end
+        yield time, record
       end
     end
   end

--- a/spec/fluent/plugin/monolog_spec.rb
+++ b/spec/fluent/plugin/monolog_spec.rb
@@ -1,11 +1,26 @@
 require 'spec_helper'
 
-describe Fluent::Plugin::Monolog do
-  it 'has a version number' do
-    expect(Fluent::Plugin::Monolog::VERSION).not_to be nil
+describe Fluent::Plugin::MonologParser do
+  include Fluent::Test::Helpers
+
+  before(:all) do
+    @parser = Fluent::Test::Driver::Parser.new(Fluent::Plugin::MonologParser)
   end
 
-  it 'does something useful' do
-    expect(false).to eq(true)
+  it 'parse monolog' do
+    text = <<-MONOLOG
+[2016-07-06 11:54:23] default.INFO: User registered {"username":"gabrieloliverio"} {"data":"Hello world!"}
+MONOLOG
+    time = record = nil
+    @parser.instance.parse(text) do |t, r|
+      time = t
+      record = r
+    end
+    expect(event_time('2016-07-06 11:54:23')).to eq(time)
+    expect(record['channel']).to eq('default')
+    expect(record['level']).to eq('INFO')
+    expect(record['message']).to eq('User registered')
+    expect(record['context']).to eq({"username"=>"gabrieloliverio"})
+    expect(record['extra']).to eq({"data"=>"Hello world!"})
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,5 @@ require 'fluent/test'
 require 'fluent/test/helpers'
 require 'fluent/test/driver/parser'
 require 'fluent/plugin/parser_monolog'
+
+Test::Unit::AutoRunner.need_auto_run = false if defined?(Test::Unit::AutoRunner)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'fluent/plugin/monolog'
+require 'test/unit'
+require 'fluent/test'
+require 'fluent/test/helpers'
+require 'fluent/test/driver/parser'
+require 'fluent/plugin/parser_monolog'


### PR DESCRIPTION
Hi, thanks for paying attention to use v0.14 Parser Plugin API.
I read this article https://qiita.com/imunew/items/632616b59820272a5447 and your plugin code.
Then, I noticed that this plugin does not have rspec expectations.

I added and some tweaking to run rspec expectations with actual monolog style text.

You can confirm to run added rspec expectations with `[bundle exec] rake spec`.
Thanks.