### PR TITLE
Fix MonologParser class hierarchy

### DIFF
--- a/lib/fluent/plugin/parser_monolog.rb
+++ b/lib/fluent/plugin/parser_monolog.rb
@@ -3,50 +3,48 @@ require 'json'
 
 module Fluent
   module Plugin
-    class TextParser
-      class MonologParser < Parser
-        Fluent::Plugin.register_parser('monolog', self)
+    class MonologParser < Parser
+      Fluent::Plugin.register_parser('monolog', self)
 
-        REGEXP = /^\[(?<time>[\d\-]+ [\d\:]+)\] (?<channel>.+)\.(?<level>(DEBUG|INFO|NOTICE|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY))\: (?<message>[^\{\}]*) (?<context>(\{.+\})|(\[.*\])) (?<extra>(\{.+\})|(\[.*\]))\s*$/
-        TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+      REGEXP = /^\[(?<time>[\d\-]+ [\d\:]+)\] (?<channel>.+)\.(?<level>(DEBUG|INFO|NOTICE|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY))\: (?<message>[^\{\}]*) (?<context>(\{.+\})|(\[.*\])) (?<extra>(\{.+\})|(\[.*\]))\s*$/
+      TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
-        def initialize
-          super
-          @time_parser = TimeParser.new(TIME_FORMAT)
-          @mutex = Mutex.new
+      def initialize
+        super
+        @time_parser = TimeParser.new(TIME_FORMAT)
+        @mutex = Mutex.new
+      end
+
+      def patterns
+        {'format' => REGEXP, 'time_format' => TIME_FORMAT}
+      end
+
+      def parse(text)
+        m = REGEXP.match(text)
+        unless m
+          yield nil, nil
+          return
         end
 
-        def patterns
-          {'format' => REGEXP, 'time_format' => TIME_FORMAT}
-        end
+        time = m['time']
+        time = @mutex.synchronize { @time_parser.parse(time) }
 
-        def parse(text)
-          m = REGEXP.match(text)
-          unless m
-            yield nil, nil
-            return
-          end
+        channel = m['channel']
+        level = m['level']
+        message = m['message']
+        context = JSON.parse(m['context'])
+        extra = JSON.parse(m['extra'])
 
-          time = m['time']
-          time = @mutex.synchronize { @time_parser.parse(time) }
+        record = {
+          "channel" => channel,
+          "level" => level,
+          "message" => message,
+          "context" => context,
+          "extra" => extra
+        }
+        record["time"] = m['time'] if @keep_time_key
 
-          channel = m['channel']
-          level = m['level']
-          message = m['message']
-          context = JSON.parse(m['context'])
-          extra = JSON.parse(m['extra'])
-
-          record = {
-              "channel" => channel,
-              "level" => level,
-              "message" => message,
-              "context" => context,
-              "extra" => extra
-          }
-          record["time"] = m['time'] if @keep_time_key
-
-          yield time, record
-        end
+        yield time, record
       end
     end
   end

--- a/test/plugin/test_parser_monolog.rb
+++ b/test/plugin/test_parser_monolog.rb
@@ -9,7 +9,7 @@ include Fluent::Test::Helpers
 class MonologParserTest < ::Test::Unit::TestCase
   def setup
     Fluent::Test.setup
-    @parser = Fluent::Test::Driver::Parser.new(Fluent::Plugin.new_parser('monolog'))
+    @parser = Fluent::Test::Driver::Parser.new(Fluent::Plugin::MonologParser)
     @expected = {
         'channel' => 'example',
         'context' => JSON.parse("{\"message\":\"foo bar\"}"),
@@ -24,9 +24,9 @@ class MonologParserTest < ::Test::Unit::TestCase
       assert_equal(event_time('2016-07-06 15:21:21', format: '%Y-%m-%d %H:%M:%S'), time)
       assert_equal(@expected, record)
     }
-    assert_equal(Fluent::Plugin::TextParser::MonologParser::REGEXP,
+    assert_equal(Fluent::Plugin::MonologParser::REGEXP,
                  @parser.instance.patterns['format'])
-    assert_equal(Fluent::Plugin::TextParser::MonologParser::TIME_FORMAT,
+    assert_equal(Fluent::Plugin::MonologParser::TIME_FORMAT,
                  @parser.instance.patterns['time_format'])
   end
 end


### PR DESCRIPTION
MonologParser class should be put under Fluent::Plugin instead of
Fluent::Plugin::TextParser due to Fluentd Plugin class hierarchy implicit convention.